### PR TITLE
Fix tab to 4 spaces for checklist

### DIFF
--- a/src/update-progress.ts
+++ b/src/update-progress.ts
@@ -81,7 +81,7 @@ export default function(lines: Line[]): Change[] {
 
         // Match list items
         if (m = line.match(/^(\s*)[*+-] \[([-x ])\] .+/)) {
-            indent = m[1].length;
+            indent = m[1].replace(/\t/,'    ').length;
 
             const checked = isLPChecked === undefined ?
                 (m[2] === "x" || m[2] === "-") : isLPChecked;


### PR DESCRIPTION
Replace tabs with 4 spaces to accept checklists padded by spaces and tabs.